### PR TITLE
v0.8.8 - Fix filtering of data before batch processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 0.8.8 - 2022-10-06
+* Fix: remove filtering of data before batch processing. Assumed to be in record
+format.
+
 # 0.8.6 - 2022-10-04
 * Patch fix: only exclude records without 'id' for batch creation.
 

--- a/helpers/batchProcess.js
+++ b/helpers/batchProcess.js
@@ -2,16 +2,11 @@ const checkPermissions = require('./checkPermissions').checkPermissions;
 const BULK_PROCESS_MAX = 50;
 
 module.exports = {
-    batchProcess: async function (operation, table, data) {
+    batchProcess: async function (operation, table, records) {
+        console.log(`Performing batch ${operation} of records in Airtable.`);
+        console.log(records);
+        
         let recordIds = [];
-        let records = [];
-
-        if (operation === "create") {
-            // records = data.filter(record => record);
-            records = data;
-        } else {
-            records = data.filter(record => record && record.id !== undefined);
-        }
     
         if (checkPermissions(operation, table, records)) {
             while(records.length > 0) {
@@ -19,7 +14,6 @@ module.exports = {
                 switch (operation) {
                     case "create":
                         let results = await table.createRecordsAsync(subset);
-                        // recordIds.push(...);
                         recordIds.push(...results);
                         break;
                     case "update":

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hcat-pge/hcat-airtable-utilities",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hcat-pge/hcat-airtable-utilities",
-      "version": "0.8.7",
+      "version": "0.8.8",
       "license": "ISC"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hcat-pge/hcat-airtable-utilities",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "A collection of utilities for creating Airtable apps for HCat",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Previously filtered out records that had `record.id === undefined` which led to unintended consequences. Some record data is just an array of IDs, others includes `field` info but no id (e.g. 'create' record data).

This change reverts to the previous state where all data is assumed to be valid before passing to `batchProcess`. If an error occurs, it should be up to the caller to catch and handle.